### PR TITLE
Rework the latest-timestamp view and prep for use.

### DIFF
--- a/mrburns/main/context_processors.py
+++ b/mrburns/main/context_processors.py
@@ -1,0 +1,8 @@
+from django.conf import settings
+
+
+def glow_variables(request):
+    return {
+        'MAP_DATA_URL': settings.MAP_DATA_URL,
+        'LATEST_TIMESTAMP_URL': settings.LATEST_TIMESTAMP_URL,
+    }

--- a/mrburns/main/static/js/main.js
+++ b/mrburns/main/static/js/main.js
@@ -44,28 +44,31 @@ Date.prototype.addHours= function(h){
 }
 
 function getJsonDataUrl() {
+    var $body = $('body');
+    var staticDataUrl = $body.data('staticDataUrl');
+    var latestTimestampUrl = $body.data('latestTimestampUrl');
+
     //TODO get the timestamp this way once deployed on dev
-    /*$.ajax({ 
-             type: "GET",
-             dataType: "json",
-             url: "/latest_data/",
-             success: function(data){        
-                rounded_timestamp = data.timestamp;
-             }
-         });*/
+    // TODO make everything async so this will work
+    /**
+     * NOTE: data.timestamp will be 0 when redis is
+     *       off, so this can be used to switch to the
+     *       "2 minutes ago" method. Alternately you
+     *       can set the LATEST_TIMESTAMP_URL setting
+     *       to the dev instance, and this will work.
+    $.getJSON(latestTimestampUrl).done(function(data){
+        rounded_timestamp = data.timestamp;
+    });
+    */
 
     var coeff = 1000 * 60;
     var date = new Date().addHours(7);
-    var url = ($('body').attr('data-static-url') != undefined) ?
-        $('body').attr('data-static-url') :
-        'https://webwewant.mozilla.org/static/';
-        
+
     //get data file from 2 mins ago
-    url = 'https://webwewant.allizom.org/static/'; //TODO for local development only
     rounded_timestamp = new Date(Math.round(date.getTime() / coeff) * 60).getTime() - 120;
-    console.log(url + 'data/stats_' + rounded_timestamp + '.json');
+    console.log(staticDataUrl + 'stats_' + rounded_timestamp + '.json');
     
-    return url + 'data/stats_' + rounded_timestamp + '.json';
+    return staticDataUrl + 'stats_' + rounded_timestamp + '.json';
 }
 
 var $stats_panel_tab_title = $('.stats-panel-tab .title');

--- a/mrburns/main/templates/base.html
+++ b/mrburns/main/templates/base.html
@@ -25,7 +25,8 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     ga('send', 'pageview');
   </script>
 </head>
-<body data-static-url="{{ STATIC_URL }}">
+<body data-static-data-url="{{ MAP_DATA_URL }}"
+      data-latest-timestamp-url="{{ LATEST_TIMESTAMP_URL }}">
 
 <div class="wrapper">
 

--- a/mrburns/main/views.py
+++ b/mrburns/main/views.py
@@ -6,7 +6,7 @@ import json
 from urllib import urlencode
 
 from django.conf import settings
-from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseNotFound
+from django.http import HttpResponse, HttpResponseBadRequest
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView, View
 
@@ -114,23 +114,16 @@ class StringsView(TemplateView):
     template_name = 'strings.html'
 
 
-class CurrentDataView(View):
+class LatestTimestampView(View):
     def get(self, request):
         if redis:
             timestamp = int(redis.get(rkeys.LATEST_TIMESTAMP) or 0)
         else:
-            timestamp = 1397098140
-        if timestamp:
-            response_data = {
-                'status': 'OK',
-                'timestamp': timestamp,
-                'filename': '/static/data/stats_{}.json'.format(timestamp),
-            }
-            return HttpResponse(json.dumps(response_data),
-                                content_type='application/json')
+            timestamp = 0
 
         response_data = {
-            'status': 'NOT FOUND',
+            'status': 'OK',
+            'timestamp': timestamp,
         }
-        return HttpResponseNotFound(json.dumps(response_data),
-                                    content_type='application/json')
+        return HttpResponse(json.dumps(response_data),
+                            content_type='application/json')

--- a/mrburns/settings/__init__.py
+++ b/mrburns/settings/__init__.py
@@ -18,3 +18,7 @@ else:
 
 
 COMPRESS_OFFLINE = not DEBUG
+
+if 'MAP_DATA_URL' not in locals():
+    # Set MAP_DATA_URL in local.py to override.
+    MAP_DATA_URL = STATIC_URL + 'data/'

--- a/mrburns/settings/base.py
+++ b/mrburns/settings/base.py
@@ -47,12 +47,25 @@ INSTALLED_APPS = (
     'django_extensions',
     'django_countries',
     'django_nose',
+    'corsheaders',
 )
 
 MIDDLEWARE_CLASSES = (
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+)
+
+TEMPLATE_CONTEXT_PROCESSORS = (
+    'django.contrib.auth.context_processors.auth',
+    'django.core.context_processors.debug',
+    'django.core.context_processors.i18n',
+    'django.core.context_processors.media',
+    'django.core.context_processors.static',
+    'django.core.context_processors.tz',
+    'django.contrib.messages.context_processors.messages'
+    'mrburns.main.context_processors.glow_variables',
 )
 
 ROOT_URLCONF = 'mrburns.urls'
@@ -89,3 +102,8 @@ COMPRESS_PRECOMPILERS = (
 DJANGO_REDIS_IGNORE_EXCEPTIONS = True
 ENABLE_REDIS = False
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_URLS_REGEX = r'^/latest-timestamp/$'
+
+LATEST_TIMESTAMP_URL = '/latest-timestamp/'

--- a/mrburns/settings/local.py-dist
+++ b/mrburns/settings/local.py-dist
@@ -8,3 +8,7 @@ from .base import *  # noqa
 # set this to something unique
 SECRET_KEY = 'it is a sekrit'
 DEBUG = TEMPLATE_DEBUG = True
+
+# uncomment to use JSON data from another source
+#MAP_DATA_URL = 'https://webwewant.allizom.org/static/data/'
+#LATEST_TIMESTAMP_URL = 'https://webwewant.allizom.org/latest-timestamp/'

--- a/mrburns/urls.py
+++ b/mrburns/urls.py
@@ -5,7 +5,7 @@
 from django.conf.urls import patterns, url
 from django.conf.urls.i18n import i18n_patterns
 
-from mrburns.main.views import (CurrentDataView, GlowView,
+from mrburns.main.views import (GlowView, LatestTimestampView,
                                 ShareView, StringsView)
 
 
@@ -16,5 +16,5 @@ urlpatterns = i18n_patterns('',
 
 urlpatterns += patterns('',
     url('^share/$', ShareView.as_view(), name='glow.share'),
-    url('^latest_data/$', CurrentDataView.as_view(), name='glow.latest')
+    url('^latest-timestamp/$', LatestTimestampView.as_view(), name='glow.latest')
 )

--- a/requirements/mrburns.txt
+++ b/requirements/mrburns.txt
@@ -37,3 +37,6 @@ nose==1.3.1
 
 # sha256: mq4WtWKGak3apeiXhymrrbvtVEco2I4LnJr3sx3Qcu0
 django-nose==1.2
+
+# sha256: xl4IPyWLB9Wti3qzkZtUq3FVvkauaoCFib6dyA2VEJ8
+django-cors-headers==0.12


### PR DESCRIPTION
Make local dev easier using the deployed data. Setup CORS headers for
latest-timestamp view for local and other testing.

@jgmize r?
