### PR TITLE
Stop youtube player when video modal is dismissed

### DIFF
--- a/mrburns/main/static/js/main.js
+++ b/mrburns/main/static/js/main.js
@@ -274,4 +274,9 @@ $(document).ready(function () {
         insertVideo(true);
     });
 
+    $('#video-modal').on('hidden.bs.modal', function (e) {
+        // Stop YouTube player when video modal is closed
+        $('#video-modal .modal-body').html('');
+    });
+
 });


### PR DESCRIPTION
Rather than messing with pause/resuming the player, I'm just removing it from the DOM. It gets added back when the modal is opened anyhow.
