### PR TITLE
Fix missing closing div and indents

### DIFF
--- a/mrburns/main/templates/stats-panel.html
+++ b/mrburns/main/templates/stats-panel.html
@@ -359,31 +359,32 @@
 
     <div class="stats-panel-column-right">
       <div class="what-is-mozilla-doing-about-it">
-      <div class="stats-share-link popover-markup">
-        <a href="#" class="trigger" data-placement="top" data-toggle="popover">
-          <i class="fa fa-share-square-o"></i>
-          <span class="title">{% trans 'Share this page' %}</span>
-        </a>
-        <div class="content hide">
-          <a class="btn btn-link share-window" target="_blank"
-              href="{{ share_stats_twitter }}">
-            <i class="fa fa-twitter"></i>
-            <span class="title">{% trans 'Twitter' %}</span>
+        <div class="stats-share-link popover-markup">
+          <a href="#" class="trigger" data-placement="top" data-toggle="popover">
+            <i class="fa fa-share-square-o"></i>
+            <span class="title">{% trans 'Share this page' %}</span>
           </a>
-          <a class="btn btn-link share-window" target="_blank"
-              href="{{ share_stats_facebook }}">
-            <i class="fa fa-facebook"></i>
-            <span class="title">{% trans 'Facebook' %}</span>
-          </a>
+          <div class="content hide">
+            <a class="btn btn-link share-window" target="_blank"
+                href="{{ share_stats_twitter }}">
+              <i class="fa fa-twitter"></i>
+              <span class="title">{% trans 'Twitter' %}</span>
+            </a>
+            <a class="btn btn-link share-window" target="_blank"
+                href="{{ share_stats_facebook }}">
+              <i class="fa fa-facebook"></i>
+              <span class="title">{% trans 'Facebook' %}</span>
+            </a>
+          </div>
         </div>
+
+        <h2></h2>
+        <div class="seperator"></div>
+
+        <p class="paragraph1"></p>
+        <p class="did-you-know">{% trans 'Did you know?' %}</p>
+        <p class="paragraph2"></p>
       </div>
-
-      <h2></h2>
-      <div class="seperator"></div>
-
-      <p class="paragraph1"></p>
-      <p class="did-you-know">{% trans 'Did you know?' %}</p>
-      <p class="paragraph2"></p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes missing privacy/legal links in Bug 990656

If you view this PR with `?w=1` to ignore white space, you'll see that the only change is an added `</div>`.
