### PR TITLE
Update bart to deal with shared logs on dev and prod.

### DIFF
--- a/smithers/bart.sh
+++ b/smithers/bart.sh
@@ -1,13 +1,15 @@
 #!/bin/sh
 
+MY_DIR=`dirname $0`
 EPOCH=`date +%s`
-NEW_LOG="/var/log/glowmo/syslog/glow.${EPOCH}.log"
+MAIN_LOG_FILE="/var/log/glow.log"
+LOG_FILE_NAME="glow.${EPOCH}.log"
+NEW_LOG="/tmp/${LOG_FILE_NAME}"
+ARCHIVE_LOG="/mnt/glow/log/${LOG_FILE_NAME}"
 
-mv -f /var/log/glow.log ${NEW_LOG}
+mv -f ${MAIN_LOG_FILE} ${NEW_LOG}
 kill -HUP `cat /var/run/syslogd.pid`
 
-cat ${NEW_LOG} | grep ' 302 ' | grep -iE 'firefox-(28|latest)' | awk '{print "lpush geoip 0," $3}' >> /tmp/redis-commands.txt
+${MY_DIR}/bart_process_log.sh ${NEW_LOG}
 
-cat /tmp/redis-commands.txt | redis-cli && rm /tmp/redis-commands.txt
-
-gzip ${NEW_LOG}
+mv ${NEW_LOG} ${ARCHIVE_LOG}

--- a/smithers/bart_dev.sh
+++ b/smithers/bart_dev.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+MY_DIR=`dirname $0`
+LOGS_DIR=/mnt/glow/log
+
+next_file=`ls -t ${LOGS_DIR}/glow.*.log | head -1`
+
+if [ -z "${next_file}" ]; then
+    exit 0
+fi
+
+${MY_DIR}/bart_process_log.sh ${next_file}
+
+gzip ${next_file}

--- a/smithers/bart_process_log.sh
+++ b/smithers/bart_process_log.sh
@@ -6,6 +6,10 @@ if [ -z "$LOG_FILE" ]; then
     exit 1
 fi
 
-cat ${LOG_FILE} | grep ' 302 ' | grep -iE 'firefox-(28|latest)' | awk '{print "lpush geoip 0," $3}' >> /tmp/redis-commands.txt
+if [ -z "${FIREFOX_VERSION}" ]; then
+    FIREFOX_VERSION=28
+fi
+
+cat ${LOG_FILE} | grep ' 302 ' | grep -iE "firefox-(${FIREFOX_VERSION}|latest)" | awk '{print "lpush geoip 0," $3}' >> /tmp/redis-commands.txt
 
 cat /tmp/redis-commands.txt | redis-cli && rm /tmp/redis-commands.txt

--- a/smithers/bart_process_log.sh
+++ b/smithers/bart_process_log.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+LOG_FILE=$1
+
+if [ -z "$LOG_FILE" ]; then
+    exit 1
+fi
+
+cat ${LOG_FILE} | grep ' 302 ' | grep -iE 'firefox-(28|latest)' | awk '{print "lpush geoip 0," $3}' >> /tmp/redis-commands.txt
+
+cat /tmp/redis-commands.txt | redis-cli && rm /tmp/redis-commands.txt


### PR DESCRIPTION
Proposal:
- Dev will run `bart_dev.sh` on cron every minute.
- Prod will run `bart.sh` on cron every minute.

Prod receives logs, processes them, and moves them to the NFS. Dev then grabs
the newest one, processes it, then gzips it so that it won't do it again.

Counter proposals and comments most welcome!

@jgmize
