### PR TITLE
Change stats data file path for better cachability.

### DIFF
--- a/mrburns/main/static/js/main.js
+++ b/mrburns/main/static/js/main.js
@@ -76,7 +76,7 @@ function getJsonDataUrl() {
         _currentDataTimestamp = latestTimestamp - 120;
     }
     console.log('Current timestamp', _currentDataTimestamp);
-    var url = staticDataUrl + 'stats_' + _currentDataTimestamp + '.json';
+    var url = staticDataUrl + 'stats/' + _currentDataTimestamp + '.json';
     console.log(url);
     return url;
 }

--- a/mrburns/main/static/js/map.js
+++ b/mrburns/main/static/js/map.js
@@ -138,6 +138,7 @@ function getContinentPositions() {
 }
 
 function drawMap(ht) {
+    var staticDataUrl = $('body').data('staticDataUrl');
     width = $('#map-container').parent().width() + 35;
     height = ht;
     
@@ -160,7 +161,7 @@ function drawMap(ht) {
         
     var path = d3.geo.path().projection(projection);
 
-    d3.json("/static/data/world-continents-110m.json", function(error, world) {
+    d3.json(staticDataUrl + "world-continents-110m.json", function(error, world) {
         var countries = topojson.feature(world, world.objects.countries);
 
         //http://geojson.org/geojson-spec.html#introduction

--- a/mrburns/settings/base.py
+++ b/mrburns/settings/base.py
@@ -12,11 +12,11 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.6/ref/settings/
 """
 
-import os
+from unipath import Path
 
 
-# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+# Build paths inside the project like this: BASE_DIR.child('sub', 'dirs')
+BASE_DIR = Path(__file__).ancestor(3).absolute()
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = TEMPLATE_DEBUG = False
@@ -86,14 +86,14 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 LOCALE_PATHS = (
-    os.path.join(BASE_DIR, 'locale'),
+    BASE_DIR.child('locale'),
 )
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_URL = '/static/'
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+STATIC_ROOT = BASE_DIR.child('static')
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'compressor.finders.CompressorFinder',

--- a/mrburns/settings/base.py
+++ b/mrburns/settings/base.py
@@ -12,11 +12,11 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.6/ref/settings/
 """
 
-from unipath import Path
+from pathlib import Path
 
 
 # Build paths inside the project like this: BASE_DIR.child('sub', 'dirs')
-BASE_DIR = Path(__file__).ancestor(3).absolute()
+BASE_DIR = Path(__file__).resolve().parents[2]
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = TEMPLATE_DEBUG = False
@@ -86,14 +86,14 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 LOCALE_PATHS = (
-    BASE_DIR.child('locale'),
+    str(BASE_DIR / 'locale'),
 )
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_URL = '/static/'
-STATIC_ROOT = BASE_DIR.child('static')
+STATIC_ROOT = str(BASE_DIR / 'static')
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'compressor.finders.CompressorFinder',

--- a/requirements/mrburns.txt
+++ b/requirements/mrburns.txt
@@ -37,3 +37,6 @@ nose==1.3.1
 
 # sha256: mq4WtWKGak3apeiXhymrrbvtVEco2I4LnJr3sx3Qcu0
 django-nose==1.2
+
+# sha256: 7wE5rDCRO0Po04ij53blNKIvgZdZZpaNKDaewDOKabc
+Unipath==1.0

--- a/requirements/mrburns.txt
+++ b/requirements/mrburns.txt
@@ -38,5 +38,5 @@ nose==1.3.1
 # sha256: mq4WtWKGak3apeiXhymrrbvtVEco2I4LnJr3sx3Qcu0
 django-nose==1.2
 
-# sha256: 7wE5rDCRO0Po04ij53blNKIvgZdZZpaNKDaewDOKabc
-Unipath==1.0
+# sha256: MGMUs3hvTFNNDPYYyw08qPHxamnbOZ0hwFcc4mYeIPY
+pathlib==1.0

--- a/smithers/milhouse.py
+++ b/smithers/milhouse.py
@@ -5,6 +5,7 @@ from __future__ import division
 import argparse
 import json
 import logging
+import os
 import signal
 import sys
 import time
@@ -157,7 +158,7 @@ def write_json_for_timestamp(timestamp):
     Write a json file for the given timestamp and data.
     """
     data = get_data_for_timestamp(timestamp)
-    filename = path.join(conf.JSON_OUTPUT_DIR, 'stats_{}.json'.format(timestamp))
+    filename = path.join(conf.JSON_OUTPUT_DIR, '{}.json'.format(timestamp))
     with open(filename, 'w') as fh:
         json.dump(data, fh)
 
@@ -169,6 +170,13 @@ def write_json_for_timestamp(timestamp):
 
 def main():
     counter = 0
+
+    # make sure output dir exists
+    try:
+        conf.JSON_OUTPUT_DIR.mkdir(parents=True)
+    except OSError:
+        log.exception('Can not create output dir: {}'.format(conf.JSON_OUTPUT_DIR))
+        return 1
 
     while True:
         if KILLED:

--- a/smithers/milhouse.py
+++ b/smithers/milhouse.py
@@ -5,11 +5,9 @@ from __future__ import division
 import argparse
 import json
 import logging
-import os
 import signal
 import sys
 import time
-from os import path
 
 from statsd import StatsClient
 
@@ -158,14 +156,14 @@ def write_json_for_timestamp(timestamp):
     Write a json file for the given timestamp and data.
     """
     data = get_data_for_timestamp(timestamp)
-    filename = path.join(conf.JSON_OUTPUT_DIR, '{}.json'.format(timestamp))
-    with open(filename, 'w') as fh:
+    jsonfile = conf.JSON_OUTPUT_DIR / '{}.json'.format(timestamp)
+    with jsonfile.open('w') as fh:
         json.dump(data, fh)
 
     # update the last processed timestamp for use in mrburns.
     redis.set(rkeys.LATEST_TIMESTAMP, timestamp)
     log.debug('Wrote file for {}'.format(timestamp))
-    log.debug(filename)
+    log.debug(jsonfile)
 
 
 def main():
@@ -173,7 +171,8 @@ def main():
 
     # make sure output dir exists
     try:
-        conf.JSON_OUTPUT_DIR.mkdir(parents=True)
+        if not conf.JSON_OUTPUT_DIR.exists():
+            conf.JSON_OUTPUT_DIR.mkdir(parents=True)
     except OSError:
         log.exception('Can not create output dir: {}'.format(conf.JSON_OUTPUT_DIR))
         return 1

--- a/smithers/smithers/conf/__init__.py
+++ b/smithers/smithers/conf/__init__.py
@@ -1,6 +1,10 @@
 from __future__ import absolute_import
+import os
 
 from .base import *  # noqa
+
+if 'DJANGO_SERVER_ENV' in os.environ:
+    from .server import *  # noqa
 
 try:
     from .local import *  # noqa

--- a/smithers/smithers/conf/base.py
+++ b/smithers/smithers/conf/base.py
@@ -1,11 +1,13 @@
-import os.path
 from os import getenv
 
+from unipath import Path
 
-BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 
-JSON_OUTPUT_DIR = os.path.join(BASE_DIR, 'JSON')
-GEOIP_DB_FILE = os.path.join(BASE_DIR, 'GeoIP2-City.mmdb')
+SMITHERS_BASE_DIR = Path(__file__).ancestor(3).absolute()
+PROJ_BASE_DIR = SMITHERS_BASE_DIR.parent
+
+JSON_OUTPUT_DIR = PROJ_BASE_DIR.child('static', 'data', 'stats')
+GEOIP_DB_FILE = SMITHERS_BASE_DIR.child('GeoIP2-City.mmdb')
 LOG_LEVEL = getenv('SMITHERS_LOG_LEVEL', 'INFO')
 
 COUNTRY_MIN_SHARE = 500

--- a/smithers/smithers/conf/base.py
+++ b/smithers/smithers/conf/base.py
@@ -1,13 +1,13 @@
 from os import getenv
 
-from unipath import Path
+from pathlib import Path
 
 
-SMITHERS_BASE_DIR = Path(__file__).ancestor(3).absolute()
+SMITHERS_BASE_DIR = Path(__file__).resolve().parents[2]
 PROJ_BASE_DIR = SMITHERS_BASE_DIR.parent
 
-JSON_OUTPUT_DIR = PROJ_BASE_DIR.child('static', 'data', 'stats')
-GEOIP_DB_FILE = SMITHERS_BASE_DIR.child('GeoIP2-City.mmdb')
+JSON_OUTPUT_DIR = PROJ_BASE_DIR.joinpath('static', 'data', 'stats')
+GEOIP_DB_FILE = SMITHERS_BASE_DIR.joinpath('GeoIP2-City.mmdb')
 LOG_LEVEL = getenv('SMITHERS_LOG_LEVEL', 'INFO')
 
 COUNTRY_MIN_SHARE = 500

--- a/smithers/smithers/conf/local.py-dist
+++ b/smithers/smithers/conf/local.py-dist
@@ -1,6 +1,6 @@
 
 # where to put your JSON files.
-# defaults to /mrburns/smithers/JSON
+# defaults to /static/data/stats
 #JSON_OUTPUT_DIR = '/var/www/some/dir'
 
 # where is your maxmind geoip db file?

--- a/smithers/smithers/conf/local.py-dist
+++ b/smithers/smithers/conf/local.py-dist
@@ -1,7 +1,8 @@
+from pathlib import Path
 
 # where to put your JSON files.
 # defaults to /static/data/stats
-#JSON_OUTPUT_DIR = '/var/www/some/dir'
+#JSON_OUTPUT_DIR = Path('/var/www/some/dir')
 
 # where is your maxmind geoip db file?
 # defaults to /mrburns/smithers/GeoIP2-City.mmdb

--- a/smithers/smithers/conf/server.py
+++ b/smithers/smithers/conf/server.py
@@ -1,0 +1,7 @@
+from os import getenv
+
+GEOIP_DB_FILE = '/usr/local/share/GeoIP/GeoIP2-City.mmdb'
+
+STATSD_HOST = 'graphite1.private.phx1.mozilla.com'
+STATSD_PORT = 8125
+STATSD_PREFIX = 'glow-workers-{}'.format(getenv('DJANGO_SERVER_ENV'))


### PR DESCRIPTION
- Put stats json files in thier own dir so we can increase cache times.
- Modify paths to files in JS and use static path from template.
- Add Unipath for cleaner and easier python path manipulation.

@jgmize r?
