### PR TITLE
Maps - performance tune-up (phase 1)

### DIFF
--- a/mrburns/main/static/css/map.less
+++ b/mrburns/main/static/css/map.less
@@ -47,7 +47,7 @@
     position: absolute;
 }
 
-.glow {
+.glows circle {
     fill: #28d917;
 }
 
@@ -103,4 +103,13 @@
 
 #map-container {
     z-index: 2;
+}
+
+.toggle-geos {
+    bottom: 80px;
+    position: absolute;
+    font-size: 12px;
+    right: 32px;
+    z-index: 10;
+    .transition(all .1s ease-in-out);
 }

--- a/mrburns/main/static/css/map.less
+++ b/mrburns/main/static/css/map.less
@@ -104,12 +104,3 @@
 #map-container {
     z-index: 2;
 }
-
-.toggle-geos {
-    bottom: 80px;
-    position: absolute;
-    font-size: 12px;
-    right: 32px;
-    z-index: 10;
-    .transition(all .1s ease-in-out);
-}

--- a/mrburns/main/static/css/stats-panel.less
+++ b/mrburns/main/static/css/stats-panel.less
@@ -143,7 +143,8 @@
 .choice-prose,
 .choice-prose-rhs-title,
 .choice-prose-rhs1,
-.choice-prose-rhs2 {
+.choice-prose-rhs2,
+.cities-label, {
     display:none;
 }
 

--- a/mrburns/main/static/js/map.js
+++ b/mrburns/main/static/js/map.js
@@ -13,7 +13,7 @@ var width,
 var glow_tick = 60000, //in ms
     chunks = 1, //how many chunks are showing the glows in during a tick
     high_download_count_threshold = 50,
-    max_simultaneous_glows = 1000,
+    max_simultaneous_glows = 700,
     number_of_medium_count_geos_to_show = 0;
 
 $(document).ready(function() {
@@ -22,22 +22,13 @@ $(document).ready(function() {
 });
 
 function assignEventListeners() {
-    //toggle listener
-    //TODO for demo purposes for jslater, will change later
-    $(".toggle-geos a").on("click", function(e) {
-        if($(this).html() == 'SHOW TOP GEOS') {
-            $(this).html('SHOW ALL GEOS');
-            
-            //show top geos
-            showing_top_geos = true;
-            user_just_switched_geos = true;
-            chunks = 1;
-            clearInterval(display_subsets_of_glows_interval);
-            $('.glows circle').hide();
-            populateGlowsFromLastTick();
-        }
-        else {
-            $(this).html('SHOW TOP GEOS');
+    //toggle glows listener
+    $(".toggle-geos").on("click", function(e) {
+        //if we're showing top geos, then switch to showing all geos
+        if($(".toggle-geos span").hasClass('currently-showing-top-geo')) {
+            $(".toggle-geos span")
+                .toggleClass('currently-showing-top-geo')
+                .html($('.show-top-cities').html());
             
             //show all geos
             showing_top_geos = false;
@@ -45,6 +36,19 @@ function assignEventListeners() {
             chunks = 6;
             clearInterval(display_subsets_of_glows_interval);
             $('.glows circle').fadeOut();
+            populateGlowsFromLastTick();
+        }
+        else {
+            $(".toggle-geos span")
+                .toggleClass('currently-showing-top-geo')
+                .html($('.show-all-cities').html());
+            
+            //show top geos
+            showing_top_geos = true;
+            user_just_switched_geos = true;
+            chunks = 1;
+            clearInterval(display_subsets_of_glows_interval);
+            $('.glows circle').hide();
             populateGlowsFromLastTick();
         }
 

--- a/mrburns/main/templates/map.html
+++ b/mrburns/main/templates/map.html
@@ -60,3 +60,7 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     </a></li>
   </ul>
 </div>
+
+<div class="toggle-geos">
+    <a href="#">SHOW ALL GEOS <!-- FOR DEMO ONLY, WILL REPLACE WITH ICONS --></a>
+</div>

--- a/mrburns/main/templates/map.html
+++ b/mrburns/main/templates/map.html
@@ -60,7 +60,3 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     </a></li>
   </ul>
 </div>
-
-<div class="toggle-geos">
-    <a href="#">SHOW ALL GEOS <!-- FOR DEMO ONLY, WILL REPLACE WITH ICONS --></a>
-</div>

--- a/mrburns/main/templates/stats-panel.html
+++ b/mrburns/main/templates/stats-panel.html
@@ -28,6 +28,11 @@
         </a>
       </div>
     </div>
+    <a href="#" class="stats-panel-link toggle-geos">
+        <i class="fa fa-circle-o"></i>
+        <span class="title currently-showing-top-geo">
+        {% trans 'Show all cities' %}</span>
+    </a>
   </nav>
   <div class="stats-panel-contents">
     <div class="key key-stats-panel">

--- a/mrburns/main/templates/stats.html
+++ b/mrburns/main/templates/stats.html
@@ -443,3 +443,6 @@
 {{ percentage }} want a Web that keeps them in control of their lives online.
 {% endblocktrans %}
 </p>
+
+<span class="cities-label show-all-cities">{% trans 'Show all cities' %}</span>
+<span class="cities-label show-top-cities">{% trans 'Show top cities' %}</span>


### PR DESCRIPTION
See this bug for details: https://bugzilla.mozilla.org/show_bug.cgi?id=985158#c5

We show a subset of glows (high-download ones) to begin with and allow the user to switch to all glows if desired. As discussed, we'll explore replacing the animation with canvas next; I think there's value in having this in master for now.

This PR also includes some, but not all (yet), of the code cleanup suggestions by alex gibson.
