### PR TITLE
Clean up display of stats content in mobile view

### DIFF
--- a/mrburns/main/static/css/stats-panel.less
+++ b/mrburns/main/static/css/stats-panel.less
@@ -102,15 +102,8 @@
 }
 
 .stats-panel-column {
-    float: left;
-    width: 570px;
-    margin-right: 40px;
+    position: relative;
     .clearfix();
-}
-
-.stats-panel-column-right {
-    float: left;
-    width: 230px;
 }
 
 .band {
@@ -120,41 +113,90 @@
 
 .chart1 {
     position: relative;
-    width: 570px;
+    padding-top: 20px;
     .clearfix();
 }
 
 .chart2 {
     position: relative;
-    width: 570px;
+    overflow: scroll;
     .clearfix();
     .country-picker {
         font-size: 18px;
-        position: absolute;
-        right: 0;
-        top: 40px;
+        .clearfix();
     }
 }
 
 .chart2 h2,
 .chart3 h2 {
-    color: #f4f4f4;
     font-size: 18px;
-    font-style: italic;
-    font-weight: 200;
-    float:left;
+    font-weight: 300;
 }
 
 .chart3 {
-    float: left;
     position: relative;
-    height: 650px;
-    width: 570px;
+    overflow: scroll;
     .clearfix();
 }
 
 .chart3 svg {
     margin-top: 10px;
+}
+
+@media (min-width: @screen-sm-min) {
+    .chart1,
+    .chart2,
+    .chart3 {
+        width: 570px;
+        h2 {
+            float: left;
+        }
+    }
+    .chart1 {
+        padding-top: 0;
+    }
+    .chart2 {
+        .country-picker {
+            font-size: 18px;
+            position: absolute;
+            right: 0;
+            top: 40px;
+        }
+    }
+    .chart3 {
+        float: left;
+        height: 650px;
+    }
+    .stats-panel-column {
+        float: left;
+        width: 570px;
+        margin-right: 40px;
+    }
+    .donut {
+        float: left;
+        text-align: inherit;
+    }
+    .donut-prose {
+        float: left;
+        padding-top: 45px;
+        width: 320px;
+        text-align: inherit;
+    }
+    .stats-panel-column-right {
+        float: left;
+        width: 230px;
+    }
+
+}
+
+.shadow-separator {
+    max-width: 100%;
+}
+
+.stats-share-link {
+    position: absolute;
+    top: 0;
+    right: 0;
 }
 
 .choice-prose,
@@ -184,7 +226,7 @@ select.country {
 }
 
 .donut {
-    float: left;
+    position: relative;
     width: 190px;
 }
 
@@ -203,17 +245,10 @@ select.country {
 }
 
 .donut-prose {
-    float: left;
-    padding-top: 45px;
-    width: 320px;
-    
-    p {
-        color: #f4f4f4;
-        font-size: 29px;
-        font-style: italic;
-        font-weight: 300;
-        line-height: 28px;
-    }
+    font-size: 26px;
+    font-weight: 300;
+    margin: 0;
+    text-align: center;
 }
 
 .key-stats-panel {
@@ -259,8 +294,7 @@ select.country {
 }
 
 .what-is-mozilla-doing-about-it {
-    position: relative;
-    
+
     h2 {
         font-size: 26px;
         font-style: italic;
@@ -282,7 +316,7 @@ select.country {
         padding-bottom: 1px;
     }
     
-    .seperator {
+    .separator {
         background-color: #f4f4f4;
         height: 2px;
         margin-bottom: 10px;

--- a/mrburns/main/static/css/stats.less
+++ b/mrburns/main/static/css/stats.less
@@ -65,6 +65,13 @@
     .clearfix();
     background: @darkBackground;
     padding: 20px;
+    .chart1 {
+        width: 100%;
+        .donut {
+            float: none;
+            margin: auto;
+        }
+    }
 }
 
 .stats-share-content {

--- a/mrburns/main/static/js/stats.js
+++ b/mrburns/main/static/js/stats.js
@@ -26,7 +26,7 @@ var icon = new Object();
 
 $(document).ready(function () {
     //set rhs
-    $('.what-is-mozilla-doing-about-it .seperator')
+    $('.what-is-mozilla-doing-about-it .separator')
         .css('background-color', color[current_choice]);
     $('.what-is-mozilla-doing-about-it h2')
         .html($('.choice-' + current_choice + '-prose-title-rhs').html());
@@ -46,7 +46,7 @@ function updateStatsPanelChoice(choice) {
     current_choice = choice;
 
     //update right-hand-side
-    $('.what-is-mozilla-doing-about-it .seperator')
+    $('.what-is-mozilla-doing-about-it .separator')
         .css('background-color', color[current_choice]);
     $('.what-is-mozilla-doing-about-it h2')
         .html($('.choice-' + current_choice + '-prose-title-rhs').html());
@@ -139,7 +139,7 @@ function drawCharts() {
 }
 
 function updateDonut(data, current_choice) {
-    $('.donut-prose p').html($('.choice-' + current_choice + '-prose').html());
+    $('.donut-prose').html($('.choice-' + current_choice + '-prose').html());
 
     d3.select('.donut-foreground')
         .transition()
@@ -160,7 +160,7 @@ function updateDonut(data, current_choice) {
 }
 
 function drawDonut(data) {
-    $('.donut-prose p').html($('.choice-' + current_choice + '-prose').html());
+    $('.donut-prose').html($('.choice-' + current_choice + '-prose').html());
   
     var width = 170,
         height = 200;

--- a/mrburns/main/templates/stats.html
+++ b/mrburns/main/templates/stats.html
@@ -19,11 +19,12 @@
     <div class="stats-panel-column">
 
       <div class="chart1">
-        <div class="donut-icon">
-          <i class="fa fa-fw fa-eye fa-4x fa-inverse"></i>
+        <div class="donut">
+          <div class="donut-icon">
+            <i class="fa fa-fw fa-eye fa-4x fa-inverse"></i>
+          </div>
         </div>
-        <div class="donut"></div>
-        <div class="donut-prose"><p></p></div>
+        <h3 class="donut-prose"></h3>
       </div>
 
       <div class="stats-panel-column-right">
@@ -110,7 +111,7 @@
           </div>
 
           <h2></h2>
-          <div class="seperator"></div>
+          <div class="separator"></div>
 
           <p class="paragraph1"></p>
           <p class="did-you-know">{% trans 'Did you know?' %}</p>
@@ -119,7 +120,7 @@
       </div>
 
       <div class="chart2">
-        <img src="{% static 'img/shadow.png' %}" class="shadow-seperator">
+        <img src="{% static 'img/shadow.png' %}" class="shadow-separator">
         <h2>{% trans 'What matters most by country?' %}</h2>
 
         <div class="country-picker">
@@ -380,7 +381,7 @@
       </div>
 
       <div class="chart3">
-        <img src="{% static 'img/shadow.png' %}" class="shadow-seperator">
+        <img src="{% static 'img/shadow.png' %}" class="shadow-separator">
         <h2>{% trans 'How does that compare globally?' %}</h2>
         <!-- stats pane is appended here -->
         <svg></svg>


### PR DESCRIPTION
Charts still have horizontal scrolling.

@almossawi: I've made some style changes to make the stats fit in the mobile view. For .chart2 and .chart3, through, I've just made their containers have `overflow: scroll;` so they have horizontal scrolling. This is pretty awkward. Is it possible to make these charts work in a narrower viewport?
