### PR TITLE
Maps and Stats tweaks

### DIFF
--- a/mrburns/main/static/js/map.js
+++ b/mrburns/main/static/js/map.js
@@ -7,6 +7,7 @@ $(document).ready(function() {
         world,
         continent_centers,
         continents,
+        counter_interval,
         populate_glows_interval,
         let_it_glow_interval,
         time_passed_interval,
@@ -189,17 +190,28 @@ $(document).ready(function() {
     }
 
     function animateCounterContinuous(last_count, current_count) {
-        $({the_value: last_count}) //from
-            .animate({the_value: current_count}, { //to
-                duration: glow_tick,
-                easing: 'swing',
-                step: function(i) {
-                    //if(Math.floor(i-last_count) % 10 == 0) {
+        clearInterval(counter_interval);
+
+        //update every 10s
+        var increment_by = Math.floor((current_count - last_count) / 6);
+        var intermediate_count = last_count + increment_by;
+        
+        $('.share_total')
+            .html(addCommas(Math.round(last_count)));
+            
+        counter_interval = setInterval(function() {
+            $({the_value: intermediate_count - increment_by}) //from
+                .animate({the_value: intermediate_count}, { //to
+                    duration: 2000,
+                    easing: 'swing',
+                    step: function(i) {
                         $('.share_total')
                             .html(addCommas(Math.round(this.the_value)));
-                    //}
-                }
-        });
+                    }
+            });
+            
+            intermediate_count += increment_by;
+        }, glow_tick / 6);  
     }
 
     function drawMap(ht, just_resized) {

--- a/mrburns/main/static/js/map.js
+++ b/mrburns/main/static/js/map.js
@@ -87,7 +87,7 @@ $(document).ready(function() {
         var min = d3.min(choice_data, function(d) { return d.count; }),
             max = d3.max(choice_data, function(d) { return d.count; });
         
-        //todo color continents per issue data per continent
+        //color continents per issue data per continent
         var color_issue_per_continent = d3.scale.linear()
             .domain([min,max])
             .range([d3.hcl(color[choice]).brighter(1), color[choice]]);

--- a/mrburns/main/static/js/stats.js
+++ b/mrburns/main/static/js/stats.js
@@ -384,7 +384,7 @@ function updateStackedBarChart(new_data) {
             })
 }
 
-function drawCountryComparisonChart(data) {console.log(data.length);
+function drawCountryComparisonChart(data) {
     if(data.length < 15) {
         $('.chart3 svg').remove();
         $('.stats-chart3-loading-data').show();
@@ -418,7 +418,10 @@ function drawCountryComparisonChart(data) {console.log(data.length);
     //add min, median, max lines and labels
     addVerticalLine(min, 'min', x_scale_country_comparison, height, bar_width);
     addVerticalLine(max, 'max', x_scale_country_comparison, height, bar_width);
-    addVerticalLine(median, 'med', x_scale_country_comparison, height, bar_width);
+    addVerticalLine(median, 'med',
+        x_scale_country_comparison, 
+        (median - min < 0.04) ? height - 20 : height,
+        bar_width);
     
     //add country comparison data
     svg.selectAll('.country-bar')


### PR DESCRIPTION
- Counter animates every 10s, this helps reduce cpu usage in Firefox.
- The median label in chart 3 on the stats page moves up by 20px when
  the median and min values are too close, to prevent them from
  overlapping.
