### PR TITLE
Stats - placeholder for chart 3 now resizes

### DIFF
--- a/mrburns/main/static/css/stats.less
+++ b/mrburns/main/static/css/stats.less
@@ -1,7 +1,13 @@
 @import "mixins.less";
 
 .stats-chart3-loading-data {
+    background-image: url(/static/img/stats-country-compare-placeholder.png);
+    background-position: left 50px;
+    background-repeat: no-repeat;
+    background-size: contain;
     display: none;
+    height: 423px;
+    width: 100%;
 }
 
 .stats-chart3-loading-data div {

--- a/mrburns/main/templates/stats.html
+++ b/mrburns/main/templates/stats.html
@@ -139,8 +139,6 @@
         <h2>{% trans 'How does that compare globally?' %}</h2>
         <!-- stats pane is appended here -->
         <div class='stats-chart3-loading-data'>
-            <img src="{% static 'img/stats-country-compare-placeholder.png' %}" 
-                class='stats-chart3-loading-data-background'>
             <div>{% trans 'We are currently gathering country-level data, please check back soon.' %}</div>
         </div>
         <svg></svg>


### PR DESCRIPTION
Modified the placeholder image, which appears when we have share data for fewer than 15 countries, so that it resizes appropriately when the window is resized.
