### PR TITLE
Convert title text to title case for EN only.

### DIFF
--- a/mrburns/main/templates/base.html
+++ b/mrburns/main/templates/base.html
@@ -6,10 +6,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 {% load staticfiles %}
 {% load compress %}
 {% load i18n %}
+{% load glow_extras %}
 <!DOCTYPE html>
 <html>
 <head>
-  <title>{{ _('The Web We Want') }}</title>
+  <title>{{ _('The Web we want')|title_lang }}</title>
   {% compress css %}
     <link rel="stylesheet" href="{% static 'css/bootstrap/bootstrap.less' %}" type="text/less" charset="utf-8">
     <link rel="stylesheet" href="{% static 'css/main.less' %}" type="text/less" charset="utf-8">
@@ -24,11 +25,11 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
     <meta property="og:description" content="{{ meta_description }}">
   {% endwith %}
 
-  <meta property="og:title" content="{% block og_title %}{{ _('The Web We Want') }}{% endblock %}">
+  <meta property="og:title" content="{% block og_title %}{{ _('The Web we want')|title_lang }}{% endblock %}">
   <meta property="og:type" content="website">
   <meta property="og:image" content="{% block page_image %}{% static 'img/glow-og-thumb.jpg' %}{% endblock %}">
   <meta property="og:url" content="{% block og_url %}{{ OG_ABS_URL }}{% endblock %}">
-  <meta property="og:site_name" content="{{ _('The Web We Want') }}">
+  <meta property="og:site_name" content="{{ _('The Web we want')|title_lang }}">
 
   <script>
     (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/mrburns/main/templatetags/glow_extras.py
+++ b/mrburns/main/templatetags/glow_extras.py
@@ -1,0 +1,17 @@
+from django import template
+from django.template.defaultfilters import title, stringfilter
+from django.utils import translation
+
+
+register = template.Library()
+
+
+@register.filter(is_safe=True)
+@stringfilter
+def title_lang(value, locale='en'):
+    """Convert to title case only for given locale."""
+    lang = translation.get_language()
+    if lang.startswith(locale):
+        return title(value)
+
+    return value


### PR DESCRIPTION
Adding "The" to the title broke l10n. However, we did have the string "The Web
we want" fully translated. It was decided to convert the EN string back to
title case automatically to avoid breaking l10n. I added a filter that allows
us to do this for any languages we choose.

@jgmize r?
@flodolo @pascalchevrel this should fix it.
