### PR TITLE
Stats - always show median above min and max

### DIFF
--- a/mrburns/main/static/js/stats.js
+++ b/mrburns/main/static/js/stats.js
@@ -428,10 +428,7 @@ function drawCountryComparisonChart(data) {
     //add min, median, max lines and labels
     addVerticalLine(min, 'min', x_scale_country_comparison, height, bar_width);
     addVerticalLine(max, 'max', x_scale_country_comparison, height, bar_width);
-    addVerticalLine(median, 'med',
-        x_scale_country_comparison, 
-        (median - min < 0.04) ? height - 20 : height,
-        bar_width);
+    addVerticalLine(median, 'med', x_scale_country_comparison, height - 20, bar_width);
     
     //add country comparison data
     svg.selectAll('.country-bar')


### PR DESCRIPTION
To account for the narrower container in mobile view, always show the
median label 20px above the min and max labels.
