### PR TITLE
Fix bugs 1001591, 999725

### DIFF
--- a/mrburns/main/static/js/map.js
+++ b/mrburns/main/static/js/map.js
@@ -15,6 +15,7 @@ $(document).ready(function() {
         let_it_glow_interval,
         time_passed_interval,
         selected_choice_map_view = '',
+        showing_choice = false,
         showing_regions = false,
         map_geo_previous = [], //previous set of map_geos
         glow_size = 1.5,
@@ -38,10 +39,20 @@ $(document).ready(function() {
 
             //did we click one of the choices, as opposed to the region view
             if ($(this).attr('id') != 'view-by-region') {
+                //are we turning this fine gentleman off?
+                if(showing_choice) {
+                    $(this).toggleClass('selected');
+                    removeMapOverlays();
+                    showing_choice = !showing_choice;
+
+                    return;
+                }
+            
                 var choice = $(this)[0].parentNode.className.split('choice-')[1];
                 selected_choice_map_view = choice;
                 removeMapOverlays();
                 showing_regions = false;
+                showing_choice = true;
 
                 //color continents per that choice and show percentages
                 addIssueBreakOutOverContinents(choice, eval('data.issue_continents.' + choice));
@@ -56,11 +67,13 @@ $(document).ready(function() {
                 $(this).toggleClass('selected');
                 removeMapOverlays();
                 showing_regions = !showing_regions;
-
+                showing_choice = false;
+                
                 return;
             }
 
             showing_regions = !showing_regions;
+            showing_choice = false;
             addTopIssueLabels();
 
             return false;

--- a/mrburns/main/static/js/stats.js
+++ b/mrburns/main/static/js/stats.js
@@ -304,8 +304,8 @@ function drawStackedBarChart(data_unsorted) {
                     return bar_y_position + bar_height + 22;
                 })
                 .text(function() {
-                    return $('.choice-' + [d.key]
-                        + ' .choice-title span').html()
+                    return $('.key-map ul .choice-' + [d.key]
+                        + ' a .choice-title span').html()
                         + ' (' + Math.round(d.value*100) + '%)';
                 })
                 .style('fill', function () {
@@ -380,8 +380,8 @@ function updateStackedBarChart(new_data) {
                                 x_marker_this + ((x_marker - x_marker_this) / 2));
                         })
                         .text(function() {
-                            return $('.choice-' + [d.key] + 
-                                ' .choice-title span').html() + ' (' 
+                            return $('.key-map ul .choice-' + [d.key]
+                                + ' a .choice-title span').html()
                                 + Math.round(new_data[d.key]*100) + '%)';
                         });
                 


### PR DESCRIPTION
- When the website is loaded in mobile view, the strings used for the
  choices are longer. Those would get picked up by chart 2. Here, we use
  the ones from the original key.
- Update map keys so that you can return the map to its off state when a
  choice option is clicked, as is the case with the region option.
