### PR TITLE
Fix bug 1003286 - map is at times empty

### DIFF
--- a/mrburns/main/static/js/map.js
+++ b/mrburns/main/static/js/map.js
@@ -498,7 +498,7 @@ $(document).ready(function() {
                 }
                 else {
                     //decrement every 1s, since each count is worth 1s of screen time
-                    if((time_in_ms % (1000 / multiplier)) === 0) {
+                    if((time_in_ms % 1000) === 0) {
                         place.count = place.count - 1;
                     }
 


### PR DESCRIPTION
Counts were being decremented every 1/10th of a second rather than every second. This did not impact low count glows, but it did impact medium to high count ones.
