### PR TITLE
Ensure only Major and Minor version numbers are used for filter.

### DIFF
--- a/smithers/smithers/conf/base.py
+++ b/smithers/smithers/conf/base.py
@@ -30,5 +30,5 @@ ARCHIVE_LOG_PATH = ARCHIVE_DIR / 'log'
 ARCHIVE_LOG_LATEST_FILE = ARCHIVE_LOG_PATH / 'latest_log_file.txt'
 ARCHIVE_JSON_PATH = ARCHIVE_DIR / 'json'
 SYSLOG_PID_FILE = '/var/run/syslogd.pid'
-FIREFOX_VERSION = '28'
+FIREFOX_VERSION = '29.0'
 LOG_HTTP_STATUS = '302'  # only redirects count for d.m.o logs

--- a/smithers/smithers/utils.py
+++ b/smithers/smithers/utils.py
@@ -39,12 +39,16 @@ def set_process_name(title):
         pass
 
 
-def get_firefox_version():
-    """Return latest version from product details JSON."""
+def _get_fx_version_from_json():
     try:
         with conf.PROD_DETAILS_DIR.joinpath('firefox_versions.json').open() as fh:
-            prod_details = json.load(fh)
+            return json.load(fh).get('LATEST_FIREFOX_VERSION', None)
     except IOError:
-        return conf.FIREFOX_VERSION
+        return None
 
-    return prod_details.get('LATEST_FIREFOX_VERSION', conf.FIREFOX_VERSION)
+
+def get_firefox_version():
+    """Return latest version from product details JSON."""
+    version = _get_fx_version_from_json() or conf.FIREFOX_VERSION
+    # we don't care about the point release
+    return '.'.join(version.split('.')[:2])

--- a/smithers/tests/test_bart.py
+++ b/smithers/tests/test_bart.py
@@ -33,6 +33,19 @@ class TestFirefoxRegex(TestCase):
         self.assertTrue(self.fx_pre_re.search(product))
         self.assertTrue(self.fx_re.search(product))
 
+    def test_patch_release(self):
+        """Should match complete auto and normal downloads for a patch release."""
+        product = 'product=firefox-29.0.1-complete'
+        self.assertTrue(self.fx_pre_re.search(product))
+        self.assertTrue(self.fx_re.search(product))
+        product = 'product=firefox-29.0.1&lang'
+        self.assertTrue(self.fx_pre_re.search(product))
+        self.assertTrue(self.fx_re.search(product))
+        # at the end of the string
+        product = 'product=firefox-29.0.1'
+        self.assertTrue(self.fx_pre_re.search(product))
+        self.assertTrue(self.fx_re.search(product))
+
     def test_latest(self):
         """Prod mode should match "latest", but pre mode should not."""
         product = 'product=firefox-latest'

--- a/smithers/tests/test_utils.py
+++ b/smithers/tests/test_utils.py
@@ -1,0 +1,29 @@
+from mock import patch
+from nose.tools import eq_
+
+from smithers import utils
+
+
+@patch('smithers.utils._get_fx_version_from_json')
+def test_get_firefox_version_with_patch(fx_version_mock):
+    """Function should strip all but Major and Minor version."""
+    fx_version_mock.return_value = '29.0.1'
+    eq_(utils.get_firefox_version(), '29.0')
+    fx_version_mock.reset_mock()
+    fx_version_mock.return_value = '30.1.1.1'
+    eq_(utils.get_firefox_version(), '30.1')
+
+
+@patch('smithers.utils._get_fx_version_from_json')
+def test_get_firefox_version_no_patch(fx_version_mock):
+    """Function should work properly with no patch version."""
+    fx_version_mock.return_value = '29.0'
+    eq_(utils.get_firefox_version(), '29.0')
+
+
+@patch.object(utils.conf, 'FIREFOX_VERSION', '30.0.1')
+@patch('smithers.utils._get_fx_version_from_json')
+def test_get_firefox_version_default(fx_version_mock):
+    """Function should fall back to configured default."""
+    fx_version_mock.return_value = None
+    eq_(utils.get_firefox_version(), '30.0')


### PR DESCRIPTION
If a "29.0.1" is released, and product details were updated, and bart were
restarted, it would look for that full version in the logs. This would likely
miss a lot of log lines as downloads of 29.0 would likely continue. This
should fix that so that it continues to only look for "firefox-29.0" followed
by anything but "b".

@jgmize r?
