### PR TITLE
Add missing closing DIV

### DIFF
--- a/mrburns/main/templates/video-modal.html
+++ b/mrburns/main/templates/video-modal.html
@@ -17,15 +17,16 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
       </div>
       <div class="modal-body"><div id="video-player"></div></div>
       <div class="modal-footer">
-      <div class="choice-footer-content">
-        <a data-ga="share-video" class="btn btn-primary share-facebook share-window" target="_blank" href="{{ share_video_facebook }}">
-          <i class="fa fa-facebook"></i>
-          <span class="title">{{ _('Facebook') }}</span>
-        </a>
-        <a data-ga="share-video" class="btn btn-primary share-twitter share-window" target="_blank" href="{{ share_video_twitter }}">
-          <i class="fa fa-twitter"></i>
-          <span class="title">{{ _('Twitter') }}</span>
-        </a>
+        <div class="choice-footer-content">
+          <a data-ga="share-video" class="btn btn-primary share-facebook share-window" target="_blank" href="{{ share_video_facebook }}">
+            <i class="fa fa-facebook"></i>
+            <span class="title">{{ _('Facebook') }}</span>
+          </a>
+          <a data-ga="share-video" class="btn btn-primary share-twitter share-window" target="_blank" href="{{ share_video_twitter }}">
+            <i class="fa fa-twitter"></i>
+            <span class="title">{{ _('Twitter') }}</span>
+          </a>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
For some reason, this was causing Firefox to not show the closing `</body>` or `</html>` tags when viewing the source.
