### PR TITLE
Replace counter with static headline and other string updates

### DIFF
--- a/mrburns/main/static/css/header.less
+++ b/mrburns/main/static/css/header.less
@@ -18,7 +18,6 @@ header {
         background-size: 100% auto;
     }
     h2 {
-        opacity: 0;
         margin-top: 10px;
         margin-bottom: 10px;
         font-weight: 300;

--- a/mrburns/main/static/js/map.js
+++ b/mrburns/main/static/js/map.js
@@ -422,7 +422,7 @@ $(document).ready(function() {
             //console.log('places length -->', places.map_geo.length);
 
             //animate the counter
-            animateCounterContinuous(places.map_previous_total, places.map_total);
+            //animateCounterContinuous(places.map_previous_total, places.map_total);
 
             //first we need to modify map_geo, by setting a random delay for each glow
             //we do this only once per tick, i.e. once per 60s

--- a/mrburns/main/templates/base.html
+++ b/mrburns/main/templates/base.html
@@ -74,6 +74,9 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
         </a></li>
         <li><a href="https://www.mozilla.org/firefox/new/">{{ _('Get Firefox') }}</a></li>
         <li class="divider"></li>
+        <li class="get-involved-link footer-link"><a href="https://www.mozilla.org/contribute/">
+          {{ _('Get Involved') }}
+        </a></li>
         <li class="privacy-link footer-link"><a href="https://www.mozilla.org/privacy/policies/websites/">
           {{ _('Privacy') }}
         </a></li>

--- a/mrburns/main/templates/base.html
+++ b/mrburns/main/templates/base.html
@@ -74,6 +74,9 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
         </a></li>
         <li><a href="https://www.mozilla.org/firefox/new/">{{ _('Get Firefox') }}</a></li>
         <li class="divider"></li>
+        <li class="get-involved-link footer-link hidden"><a href="#">
+          {{ _('FAQ') }}
+        </a></li>
         <li class="get-involved-link footer-link"><a href="https://www.mozilla.org/contribute/">
           {{ _('Get Involved') }}
         </a></li>

--- a/mrburns/main/templates/base.html
+++ b/mrburns/main/templates/base.html
@@ -51,11 +51,9 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
   <header>
     <h1>{{ _('Firefox') }}</h1>
     <h2 class="header-join-content{% if is_long_headline %} header-long{% endif %}">
-      {% comment %}
-      question-circle link can't have a space after title string
-      {% endcomment %}
-      {% blocktrans with count=count_footnote|safe %}
-        Join {{ count }} people shaping the future of the Web{% endblocktrans %}
+    {% if LANGUAGE_CODE == 'en' %}
+      {{ _('Thanks for helping to shape the future of the Web.')}}
+    {% endif %}
     </h2>
     <ul class="actions hidden-xs list-unstyled">
       <li><a class="btn btn-download" href="https://www.mozilla.org/firefox/new/#download-fx">


### PR DESCRIPTION
- [Bug 1002672](https://bugzilla.mozilla.org/show_bug.cgi?id=1002672) - **Replace Counter**
  - Updated the JS to check for the share_total span and short-circuit the counter logic if the element doesn't exist.
  - Updated the CSS to show the headline immediately, rather than waiting for the count to fade-in.
- [Bug 1002677](https://bugzilla.mozilla.org/show_bug.cgi?id=1002677) - **Add Link To Get Involved Page**
- [Bug 1002673](https://bugzilla.mozilla.org/show_bug.cgi?id=1002673) - **Add Link To Faq**
  - Just a placeholder, hidden by CSS, to get the string in for l10n
